### PR TITLE
Improve clarity and grammatical accuracy in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 This is a sample implementation for using light client with an android app. <br/>
 
 To use this follow the given steps- 
-1. Take your package name (here it is, Java.com.example.availlibrary.AvailLightClientLib) and compile light client for your package id using the given [steps](https://github.com/availproject/light-client-lib).
-2. Place compiled .so files in src/main/jni/arm64-v8a directory in the library.
-3. Place header and libc++_shared.so in the same path.
+1. Take your package name (here it is, Java.com.example.availlibrary.AvailLightClientLib) and compile the light client for your package ID using the given [steps](https://github.com/availproject/light-client-lib).
+2. Place the compiled .so files in src/main/jni/arm64-v8a directory in the library.
+3. Place the header file and libc++_shared.so in the same directory.
 4. Use this library and all its exposed function in your app.
 
 ## Contribution Guidelines


### PR DESCRIPTION
Fixed:

Adjusted phrasing in "Place compiled .so files in src/main/jni/arm64-v8a directory in the library." to make it consistent with the rest of the document.
Changed "and compile light client for your package id" to "and compile the light client for your package ID" for grammatical accuracy.
Replaced "Place header and libc++_shared.so in the same path." with "Place the header file and libc++_shared.so in the same directory." for better clarity and correctness.
Why it's useful:
These changes improve clarity, consistency, and grammatical accuracy, making the instructions easier to follow.